### PR TITLE
add role to the jwt payload

### DIFF
--- a/src/users/controller.py
+++ b/src/users/controller.py
@@ -49,7 +49,7 @@ class UserController:
                 return jsonify({"message": "Username already exists"}), 400
             return jsonify({"message": "Email already exists"}), 400
         return jsonify({"message": is_valid}), 400
-    
+
     def get_role(self, data):
         sql = """SELECT role FROM users WHERE username = '{}'"""
         self.cur.execute(sql.format(data['username']))

--- a/src/users/controller.py
+++ b/src/users/controller.py
@@ -2,6 +2,7 @@ from database_handler import DbConn
 from flask import jsonify
 from werkzeug.security import check_password_hash, generate_password_hash
 from flask_jwt_extended import create_access_token
+from datetime import timedelta
 from src.validators.user_validator import ValidateUser
 
 
@@ -48,6 +49,13 @@ class UserController:
                 return jsonify({"message": "Username already exists"}), 400
             return jsonify({"message": "Email already exists"}), 400
         return jsonify({"message": is_valid}), 400
+    
+    def get_role(self, data):
+        sql = """SELECT role FROM users WHERE username = '{}'"""
+        self.cur.execute(sql.format(data['username']))
+        role = self.cur.fetchone()
+        if role:
+            return role
 
     def login_user(self, data):
         """Logs in a user
@@ -58,6 +66,12 @@ class UserController:
         sql = """SELECT username,password FROM users WHERE username='{}'"""
         validate = ValidateUser(data)
         is_valid = validate.validate_login()
+        role = self.get_role(data)
+        identity = {
+            'username': data['username'],
+            'role': role
+        }
+        expires = timedelta(hours=23)
         if is_valid == "valid":
             self.cur.execute(sql.format(data['username']))
             db_user = self.cur.fetchone()
@@ -66,7 +80,7 @@ class UserController:
             if not check_password_hash(db_user[1], data['password']):
                 return jsonify({'message': 'Invalid password'}), 400
             else:
-                access_token = create_access_token(identity=data['username'])
+                access_token = create_access_token(identity=identity, expires_delta=expires)
                 return jsonify({'message': 'successfully logged in',
                                 'token': access_token
                                 }), 200

--- a/src/validators/user_validator.py
+++ b/src/validators/user_validator.py
@@ -70,6 +70,12 @@ class ValidateUser:
         else:
             return "valid"
 
+    def validate_user_role(self):
+        if self.data['role'] != 'Admin' and \
+            self.data['role'] != 'Teacher' and \
+            self.data['role'] != 'Institution':
+            return "Role must be either Admin, Teacher, Institution"
+
     def is_valid(self):
         """combines all field validation"""
         if isinstance(self.validate_name(), str):
@@ -78,6 +84,7 @@ class ValidateUser:
             return self.validate_email()
         elif isinstance(self.validate_password(), str):
             return self.validate_password()
-
+        elif isinstance(self.validate_user_role(), str):
+            return self.validate_user_role()
         else:
             return "valid"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -7,7 +7,7 @@ class TestUser(unittest.TestCase):
     def setUp(self):
         """Sets up the user class."""
         self.user = User(**{'email': 'maria@gmail.com', 'firstname': 'maria',
-                            'role': 'user'})
+                            'role': 'Admin'})
 
     def test_user_model(self):
         """GIVEN a User model.
@@ -18,4 +18,4 @@ class TestUser(unittest.TestCase):
         """
         self.assertEqual(self.user.email, 'maria@gmail.com')
         self.assertEqual(self.user.firstname, 'maria')
-        self.assertEqual(self.user.role, 'user')
+        self.assertEqual(self.user.role, 'Admin')

--- a/tests/test_user_signup.py
+++ b/tests/test_user_signup.py
@@ -32,7 +32,7 @@ class TestUserSignUp(unittest.TestCase):
         '''
         output = self.signup_user(
             'kizza5', 'Test123', 'test5@test.com', 'kizza', 'samuel',
-            'teacher', 'Test123')
+            'Teacher', 'Test123')
         self.assertIn('user registered successfully',
                       output.data.decode('utf-8'))
 


### PR DESCRIPTION
## Description
- adds role to jwt payload for login purposes at the frontend

Fixes #38 

## How has this been tested?
- Fetch this branch `git fetch origin bg-add-role-to-jwt`
- Checkout the branch `git checkout bg-add-role-to-jwt`
- Setup the virtual environment `python -m venv venv`
- Activate the virtual environment `source venv/bin/activate`
- Run the server `python run.py`
- Test the login endpoint with postman `http://127.0.0.1:5000/api/v1/auth/login`
- Obtain the returned JWT token
- Navigate to `https://jwt.io` and add the token to encoded section
- View the payload at the decoded section to ensure role is one of the added identities

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
