### PR TITLE
Ft view all courses

### DIFF
--- a/src/courses/controller.py
+++ b/src/courses/controller.py
@@ -47,3 +47,10 @@ class CourseController:
         row = self.cur.fetchone()
         if row:
             return row
+
+    def query_all_courses(self):
+        ''' selects all available courses from the database '''
+        sql = """ SELECT * FROM courses  """   
+        self.cur.execute(sql)
+        rows = self.cur.fetchall()
+        return rows

--- a/src/courses/controller.py
+++ b/src/courses/controller.py
@@ -50,7 +50,7 @@ class CourseController:
 
     def query_all_courses(self):
         ''' selects all available courses from the database '''
-        sql = """ SELECT * FROM courses  """   
+        sql = """ SELECT * FROM courses  """
         self.cur.execute(sql)
         rows = self.cur.fetchall()
         return rows

--- a/src/courses/view.py
+++ b/src/courses/view.py
@@ -105,3 +105,19 @@ def update_course(course_id):
             return jsonify({"message": "course id should be an integer"}), 400
     else:
         return jsonify({"message": "course details not provided"}), 400
+
+
+@course.route('/api/v1/courses', methods=['GET'])
+def view_all_courses():
+    """
+    Function enables user to view all the available courses from the database.
+    """
+    if not course_controller.query_all_courses():
+        return jsonify({
+            'message': 'No available courses in the database'
+        }), 400
+    courses = course_controller.query_all_courses()
+    return jsonify({
+        'courses': courses,
+        'message': 'courses fetched!'
+    }), 200


### PR DESCRIPTION
## Description

A user should be able to view available courses:
Fixes #21  

## Screenshots
![view_all_courses](https://user-images.githubusercontent.com/43172429/83140328-c183ae00-a0a2-11ea-8c06-5bbcb3e0db12.JPG)

## How Has This Been Tested?
- Fetch this branch using `git fetch origin ft-update_course
- Setup the virtual environment with `python3 -m venv venv`
- Activate the virtual environment using `source venv/bin/activate` for linux or `source venv/scripts/activate` for windows
- Install dependencies using `pip install -r requirements.txt`
- Run the server with `python run.py`
- Test the update endpoint in postman with `http://127.0.0.1:5000/api/v1/courses`
## Screenshots (if applicable, else remove this line / section)


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
