### PR TITLE
add ability to enroll for course

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,19 @@ This project addresses the following SDG targets:
 
 ## Usage
 
-| REQUEST | ROUTE                         | FUNCTIONALITY             |
-| ------- | ----------------------------- | ------------------------- |
-| GET     | api/v1/courses                | Fetches all courses       |
-| GET     | api/v1/courses/&lt;course_id> | Fetches a single course   |
-| POST    | api/v1/courses                | Adds a new course         |
-| PUT     | api/v1/courses/&lt;course_id> | Updates a single course   |
-| DELETE  | api/v1/courses/&lt;course_id> | Deletes a course          |
-| POST    | api/v1/auth/login             | Logs in a user            |
-| POST    | api/v1/auth/signup            | Registers a user          |
-| POST    | api/v1/auth/logout            | Logs out a user           |
-| POST    | api/v1/categories             | Creates a course category |
-| GET     | api/v1/auth/profile           | Fetches a user's profile  |
+| REQUEST | ROUTE                                | FUNCTIONALITY             |
+| ------- | ------------------------------------ | ------------------------- |
+| GET     | api/v1/courses                       | Fetches all courses       |
+| GET     | api/v1/courses/&lt;course_id>        | Fetches a single course   |
+| POST    | api/v1/courses                       | Adds a new course         |
+| PUT     | api/v1/courses/&lt;course_id>        | Updates a single course   |
+| DELETE  | api/v1/courses/&lt;course_id>        | Deletes a course          |
+| POST    | api/v1/auth/login                    | Logs in a user            |
+| POST    | api/v1/auth/signup                   | Registers a user          |
+| POST    | api/v1/auth/logout                   | Logs out a user           |
+| POST    | api/v1/categories                    | Creates a course category |
+| GET     | api/v1/auth/profile                  | Fetches a user's profile  |
+| POST    | api/v1/courses/&lt;course_id>/enroll | Enroll for a course       |
 
 ## Setup
 

--- a/database_handler.py
+++ b/database_handler.py
@@ -26,6 +26,13 @@ class DbConn:
             password VARCHAR(100) NOT NULL,
             role VARCHAR(100) NOT NULL); ''')
 
+    def create_enrolled_table(self):
+        """A function to create the course table."""
+        self.cur.execute('''CREATE TABLE IF NOT EXISTS enrollement
+        (EnrollID  SERIAL PRIMARY KEY  NOT NULL,
+         CourseID INTEGER REFERENCES courses(CourseID) ON DELETE CASCADE,
+         username VARCHAR(100) REFERENCES users(username) ON DELETE CASCADE); ''')
+
     def create_organizations_table(self):
         """A function to create the organization table."""
         self.cur.execute('''CREATE TABLE IF NOT EXISTS organizations

--- a/src/courses/controller.py
+++ b/src/courses/controller.py
@@ -1,5 +1,5 @@
 from database_handler import DbConn
-
+from flask_jwt_extended import get_jwt_identity
 
 class CourseController:
 
@@ -11,6 +11,7 @@ class CourseController:
         self.cur = conn.create_connection()
         conn.create_organizations_table()
         conn.create_courses_table()
+        conn.create_enrolled_table()
 
     def create_course(self, data):
         """Creates a course."""
@@ -65,3 +66,21 @@ class CourseController:
                 "organization_name": row[6]
                 })
         return courses
+
+    def check_if_already_enrolled(self, course_id):
+        """Checks if a user has already enrolled for the course"""
+        username = get_jwt_identity()['username']
+        sql = """SELECT * FROM enrollement WHERE username= '{}' and CourseID='{}'"""
+        self.cur.execute(sql.format(username, course_id))
+        row = self.cur.fetchone()
+        print(row)
+        if row:
+            return True
+        else:
+            return False
+
+    def enroll_course(self, course_id):
+        """Enroll for a course"""
+        username = get_jwt_identity()['username']
+        query = """INSERT INTO enrollement(CourseID, username) VALUES('{}', '{}')"""
+        self.cur.execute(query.format(course_id, username))

--- a/src/courses/view.py
+++ b/src/courses/view.py
@@ -1,7 +1,9 @@
-from flask import jsonify, Blueprint, request
-from .controller import CourseController
-from ..validators.course_validator import ValidateCourse
 import psycopg2
+from flask import Blueprint, jsonify, request
+from flask_jwt_extended import jwt_required
+
+from ..validators.course_validator import ValidateCourse
+from .controller import CourseController
 
 course = Blueprint('course', __name__)
 course_controller = CourseController()
@@ -125,3 +127,24 @@ def view_all_courses():
         'courses': courses,
         'message': 'courses fetched!'
     }), 200
+
+@course.route('/api/v1/courses/<course_id>/enroll', methods=['POST'])
+@jwt_required
+def enroll_for_course(course_id):
+    """
+    Function enables user to enroll for a specific course.
+    """
+    if not course_controller.query_course(course_id):
+        return jsonify({
+            'message': 'course doesnot exist in database'
+        }), 400
+
+    elif course_controller.check_if_already_enrolled(course_id):
+        return jsonify({
+            'message': 'already enrolled for this course'
+        }), 400
+    else:
+        course_controller.enroll_course(course_id)
+        return jsonify({
+            'message': 'successfully enrolled'
+        }), 200


### PR DESCRIPTION
## Description
- add ability to enroll for a course

Fixes #47 

## How Has This Been Tested?
 - Fetch the branch at `git fetch origin ft-enroll-for-course`
- Checkout the branch using `git checkout ft-enroll-for-course`
- Set up a virtual environment with `python3 -m venv`
- Activate the virtual environment with `source venv/bin/activate`
- Install requirements with `pip install -r requirements.txt`
- Start the development server at `python run.py`
- Login with [postman](https://www.postman.com/) using `http://127.0.0.1:5000/api/v1/auth/login`
- Obtain a token and add it to the authorization header as Bearer token
- Make a POST request to `http://127.0.0.1:5000/api/v1/courses/<id>/enroll` to enroll for a specific course

## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
