### PR TITLE
add ability to add module content to a specific module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,25 @@ This project addresses the following SDG targets:
 
 ## Usage
 
-| REQUEST | ROUTE                                 | FUNCTIONALITY             |
-| ------- | ------------------------------------- | ------------------------- |
-| GET     | api/v1/courses                        | Fetches all courses       |
-| GET     | api/v1/courses/&lt;course_id>         | Fetches a single course   |
-| POST    | api/v1/courses                        | Adds a new course         |
-| PUT     | api/v1/courses/&lt;course_id>         | Updates a single course   |
-| DELETE  | api/v1/courses/&lt;course_id>         | Deletes a course          |
-| POST    | api/v1/auth/login                     | Logs in a user            |
-| POST    | api/v1/auth/signup                    | Registers a user          |
-| POST    | api/v1/auth/logout                    | Logs out a user           |
-| POST    | api/v1/categories                     | Creates a course category |
-| GET     | api/v1/auth/profile                   | Fetches a user's profile  |
-| POST    | api/v1/courses/&lt;course_id>/enroll  | Enroll for a course       |
-| POST    | api/v1/courses/&lt;course_id>/modules | Add module to course      |
-| GET     | api/v1/courses/&lt;course_id>/modules | Fetch modules on a course |
+| REQUEST | ROUTE                                 | FUNCTIONALITY                             |
+| ------- | ------------------------------------- | ----------------------------------------- |
+| GET     | api/v1/courses                        | Fetches all courses                       |
+| GET     | api/v1/courses/&lt;course_id>         | Fetches a single course                   |
+| POST    | api/v1/courses                        | Adds a new course                         |
+| PUT     | api/v1/courses/&lt;course_id>         | Updates a single course                   |
+| DELETE  | api/v1/courses/&lt;course_id>         | Deletes a course                          |
+| POST    | api/v1/auth/login                     | Logs in a user                            |
+| POST    | api/v1/auth/signup                    | Registers a user                          |
+| POST    | api/v1/auth/logout                    | Logs out a user                           |
+| POST    | api/v1/categories                     | Creates a course category                 |
+| GET     | api/v1/auth/profile                   | Fetches a user's profile                  |
+| POST    | api/v1/courses/&lt;course_id>/enroll  | Enroll for a course                       |
+| POST    | api/v1/courses/&lt;course_id>/modules | Add module to course                      |
+| GET     | api/v1/courses/&lt;course_id>/modules | Fetch modules on a course                 |
+| POST    | api/v1/courses/&lt;course_id>/modules | Register a course module                  |
+| GET     | api/v1/courses/&lt;course_id>/modules | Fetch modules on a course                 |
+| GET     | api/v1/modules/&lt;module_id>         | Fetch module content for a single module  |
+| POST    | api/v1/modules/&lt;module_id>         | Create module content for a single module |
 
 ## Setup
 

--- a/database_handler.py
+++ b/database_handler.py
@@ -39,9 +39,17 @@ class DbConn:
             ModuleID SERIAL PRIMARY KEY NOT NULL,
             module_title VARCHAR(250) NOT NULL,
             module_description VARCHAR(255) NOT NULL,
-            module_content VARCHAR(500),
             module_date_added DATE NOT NULL,
             CourseID INTEGER REFERENCES courses(CourseID) ON DELETE CASCADE);''')
+
+    def create_modules_content_table(self):
+        """Creates modules content table."""
+        self.cur.execute('''CREATE TABLE IF NOT EXISTS modules_content(
+            ModuleContentID SERIAL PRIMARY KEY NOT NULL,
+            module_content VARCHAR(500) NOT NULL,
+            module_content_title VARCHAR(255) NOT NULL,
+            module_content_date_added DATE NOT NULL,
+            ModuleID INTEGER REFERENCES modules(ModuleID) ON DELETE CASCADE);''')
 
 
     def create_organizations_table(self):

--- a/src/courseModules/model.py
+++ b/src/courseModules/model.py
@@ -3,5 +3,4 @@ class CourseModule:
         self.module_id = module_id
         self.module_title = module_title
         self.module_description = module_description
-        self.module_content = module_content
         self.date_added = date_added

--- a/src/courseModules/view.py
+++ b/src/courseModules/view.py
@@ -40,3 +40,23 @@ def get_modules(course_id):
         return jsonify({
             'message': 'course doesnot exist in database'
         }), 400
+
+@module.route('/api/v1/modules/<module_id>', methods=['POST'])
+def add_module_content(module_id):
+    data = request.get_json()
+    if data:
+        return module_controller.register_module_content(data, module_id)
+    else:
+        return jsonify({"message": "no data provided"}), 400
+
+@module.route('/api/v1/modules/<module_id>', methods=['GET'])
+def fetch_module_content(module_id):
+    """Fetches module content for a specific module"""
+    if not module_controller.check_module_id_exists(module_id):
+        return jsonify({
+            'message': 'module {} does not exist'.format(module_id)
+        }), 400
+    modules = module_controller.fetch_module_content(module_id)
+    return jsonify({
+        'modules': modules,
+    }), 200

--- a/src/validators/module_validator.py
+++ b/src/validators/module_validator.py
@@ -5,7 +5,7 @@ class ModuleValidator:
 
     def validate_module_fields(self):
         """Validates module details"""
-        module_fields = ["module_title","module_description","module_content"]
+        module_fields = ["module_title","module_description"]
         for field in module_fields:
             if not self.data[field]:
                 return field + " cannot be blank"
@@ -14,9 +14,27 @@ class ModuleValidator:
             if not isinstance(self.data[field], str):
                 return "Enter string value at {}".format(field)
 
+    def validate_module_content(self):
+        """Validates module content"""
+        module_content_fields=["module_content", "module_content_title"]
+        for field in module_content_fields:
+            if not self.data[field]:
+                return field + "cannot be blank"
+            if field not in self.data.keys():
+                return field + " is missing"
+            if not isinstance(self.data[field], str):
+                return "Enter string value at {}".format(field)
+
+
     def is_valid(self):
         """combines all field validation"""
         if isinstance(self.validate_module_fields(), str):
             return self.validate_module_fields()
+        else:
+            return "valid"
+
+    def is_module_valid(self):
+        if isinstance(self.validate_module_content(), str):
+            return self.validate_module_content()
         else:
             return "valid"


### PR DESCRIPTION
## Description
- sets up ability to add module content to a specific module and view it

Fixes #53 

## How Has This Been Tested?
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code etc.

## Screenshots (if applicable, else remove this line / section)
- Fetch the branch at `git fetch origin bg-fix-module-content`
- Checkout the branch using `git checkout bg-fix-module-content`
- Set up a virtual environment with `python3 -m venv`
- Activate the virtual environment with `source venv/bin/activate`
- Install requirements with `pip install -r requirements.txt`
- Start the development server at `python run.py`
- Make a GET request to `http://127.0.0.1:5000/api/v1/modules/<module_id>` to fetch a module content for a specific module
- Make a POST request to  `http://127.0.0.1:5000/api/v1/modules/<module_id>`  to post module content for a specific module
```json
 {
	"module_content_title": "Module1",
	"module_content": "This is module 1"
}
```
## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
