### PR TITLE
User should be able to view a single article

### DIFF
--- a/src/articles/view.py
+++ b/src/articles/view.py
@@ -1,7 +1,5 @@
-from flask import jsonify, Blueprint, request
+from flask import jsonify, Blueprint
 from .controller import ArticleController
-from ..validators.article_validator import ValidateArticle
-import psycopg2
 
 article = Blueprint('article', __name__)
 article_controller = ArticleController()


### PR DESCRIPTION
## Description
A user should be able to view available courses:
Fixes #57

## How Has This Been Tested?
- Fetch this branch using `git fetch origin ft-view_single_article`
- Setup the virtual environment with `python3 -m venv venv`
- Activate the virtual environment using `source venv/bin/activate` for linux or `source venv/scripts/activate` for windows
- Install dependencies using `pip install -r requirements.txt`
- Run the server with `python run.py`
- Test the update endpoint in postman with `http://127.0.0.1:5000/api/v1/articles/<article_id>`


## Screenshots 
![view-single-article](https://user-images.githubusercontent.com/43172429/83947326-2342c700-a7cb-11ea-8083-9813dd6444d9.JPG)



## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
