### PR TITLE
Add route protection to courses feature

### DIFF
--- a/src/courses/view.py
+++ b/src/courses/view.py
@@ -1,15 +1,38 @@
 import psycopg2
 from flask import Blueprint, jsonify, request
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import jwt_required, verify_jwt_in_request, get_jwt_identity
 
 from ..validators.course_validator import ValidateCourse
 from .controller import CourseController
 
+from functools import wraps
+
+
 course = Blueprint('course', __name__)
 course_controller = CourseController()
 
+# This custom decorator that verifies the JWT is present in
+# the request, as well as insure that the user has a role of
+# `Admin` in the access token
+
+
+def admin_required(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        verify_jwt_in_request()
+        current_user = get_jwt_identity()
+        role = str(current_user['role'])[1:-1].replace('\'', '')
+        #print(role)
+        if role == 'Admin':
+            return f(*args, **kwargs)
+        else:
+            return jsonify(msg='Only Course Administrators can perform this action!'), 403
+
+    return wrapper
+
 
 @course.route('/api/v1/courses', methods=['POST'])
+@admin_required
 def add_new_course():
     """Registers a Course."""
     data = request.get_json()
@@ -32,6 +55,7 @@ def add_new_course():
 
 
 @course.route('/api/v1/courses/<course_id>', methods=['DELETE'])
+@admin_required
 def delete_course(course_id):
     """
     Function enables admin to delete a course from the database.
@@ -83,6 +107,7 @@ def view_course(course_id):
 
 
 @course.route('/api/v1/courses/<course_id>', methods=['PUT'])
+@admin_required
 def update_course(course_id):
     """
     Function enables user to modify a course from the database.
@@ -97,8 +122,13 @@ def update_course(course_id):
                 return jsonify({
                     'message': 'Course does not exist in database'
                 }), 400
+<<<<<<< HEAD
             elif validate_course.validate_course_category() and \
                validate_course.validate_course_duration():
+=======
+            elif validate_course.validate_course_name() and \
+                    validate_course.validate_course_duration():
+>>>>>>> Added custom decorator for admin protected route
                 course_controller.update_course(data, course_id)
                 return jsonify({"message": "course updated successfully"}), 200
             elif not validate_course.validate_course_category():
@@ -127,6 +157,7 @@ def view_all_courses():
         'courses': courses,
         'message': 'courses fetched!'
     }), 200
+
 
 @course.route('/api/v1/courses/<course_id>/enroll', methods=['POST'])
 @jwt_required

--- a/src/courses/view.py
+++ b/src/courses/view.py
@@ -122,18 +122,8 @@ def update_course(course_id):
                 return jsonify({
                     'message': 'Course does not exist in database'
                 }), 400
-<<<<<<< HEAD
-<<<<<<< HEAD
-            elif validate_course.validate_course_category() and \
-               validate_course.validate_course_duration():
-=======
             elif validate_course.validate_course_name() and \
                     validate_course.validate_course_duration():
->>>>>>> Added custom decorator for admin protected route
-=======
-            elif validate_course.validate_course_name() and \
-                    validate_course.validate_course_duration():
->>>>>>> 7c0b74da3dd88465b41c64b0583e808007975251
                 course_controller.update_course(data, course_id)
                 return jsonify({"message": "course updated successfully"}), 200
             elif not validate_course.validate_course_category():


### PR DESCRIPTION
## Description
Only a user with administrator rights should be able to;
1. Create a Course
2. Update a Course
3. Delete a Course

Fixes #46 

## How Has This Been Tested?
- Fetch this branch using `git fetch origin add_route_protection_to_courses_feature`
- Setup the virtual environment with `python3 -m venv venv`
- Activate the virtual environment using `source venv/bin/activate` for linux or `source venv/scripts/activate` for windows
- Install dependencies using `pip install -r requirements.txt`
- Run the server with `python run.py`
- Login as Admin to obtain access token using endpoint in postman with `http://localhost:5000/api/v1/auth/login`
- Then test the add a course endpoint in postman with `http://localhost:5000/api/v1/courses`

## Screenshots


## Checklist:
<!--- Put an `x` in all the boxes that apply ! -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added necessary inline code documentation
- [ ] I have added tests that prove my fix is effective and that this feature works
- [ ] New and existing unit tests pass locally with my changes
